### PR TITLE
Update image names from nedtop to rocinante in build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: nedtop
+          - image_name: rocinante
             base_image: ghcr.io/ublue-os/bluefin-dx:latest
-          - image_name: nedtop-nvidia
+          - image_name: rocinante-nvidia
             base_image: ghcr.io/ublue-os/bluefin-dx-nvidia:latest
 
     permissions:


### PR DESCRIPTION
Complete the project rename by updating the GitHub Actions workflow matrix to use rocinante and rocinante-nvidia image names.