### PR TITLE
Add nvidia-container-toolkit for Podman GPU access

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -12,6 +12,12 @@ set -ouex pipefail
 # this installs a package from fedora repos
 dnf5 install -y --skip-unavailable tmux gnupg2-scdaemon
 
+# Install nvidia-container-toolkit for Podman GPU access (nvidia variants only)
+# The repo is provided by ublue-os-nvidia-addons but package needs explicit install
+if dnf5 repolist --disabled | grep -q nvidia-container-toolkit; then
+    dnf5 install -y --enablerepo=nvidia-container-toolkit nvidia-container-toolkit
+fi
+
 # Use a COPR Example:
 #
 # dnf5 -y copr enable ublue-os/staging


### PR DESCRIPTION
## Summary
- Add nvidia-container-toolkit package to nvidia image variants
- Enables Podman GPU passthrough via CDI (Container Device Interface)
- Conditional install: only runs when nvidia-container-toolkit repo is available

## Problem
The base `bluefin-dx-nvidia-open` image includes `ublue-os-nvidia-addons` which adds the nvidia-container-toolkit repo, but doesn't install the actual package. This caused GPU container access to fail:

```
Error: OCI runtime error: crun: error executing hook `/usr/bin/nvidia-cdi-hook` (exit code: 1)
```

## Solution
Conditionally install `nvidia-container-toolkit` when building nvidia variants. The check for the repo ensures the base rocinante image (non-nvidia) is unaffected.

## Test plan
- [ ] Build rocinante-nvidia image
- [ ] Rebase desktop to new image
- [ ] Verify GPU access: `podman run --rm --device nvidia.com/gpu=all nvidia/cuda:12.2.0-base-ubuntu22.04 nvidia-smi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)