### PR TITLE
Fix justfile heredoc syntax errors

### DIFF
--- a/system_files/usr/share/ublue-os/just/rocinante.just
+++ b/system_files/usr/share/ublue-os/just/rocinante.just
@@ -18,10 +18,8 @@ setup-yubikey-ssh:
     # Step 2: Configure SSH_AUTH_SOCK via environment.d
     mkdir -p ~/.config/environment.d
     if [[ ! -f ~/.config/environment.d/10-ssh-agent.conf ]]; then
-        cat > ~/.config/environment.d/10-ssh-agent.conf << 'EOF'
-# Use systemd ssh-agent for FIDO2/sk-ssh keys (YubiKey Bio/5)
-SSH_AUTH_SOCK=${XDG_RUNTIME_DIR}/ssh-agent.socket
-EOF
+        echo "# Use systemd ssh-agent for FIDO2/sk-ssh keys (YubiKey Bio/5)" > ~/.config/environment.d/10-ssh-agent.conf
+        echo 'SSH_AUTH_SOCK=${XDG_RUNTIME_DIR}/ssh-agent.socket' >> ~/.config/environment.d/10-ssh-agent.conf
         echo "Created ~/.config/environment.d/10-ssh-agent.conf"
     else
         echo "~/.config/environment.d/10-ssh-agent.conf already exists"
@@ -109,12 +107,10 @@ enable-yubikey-gpg:
     chmod 700 ~/.gnupg
 
     if [[ ! -f ~/.gnupg/scdaemon.conf ]]; then
-        cat > ~/.gnupg/scdaemon.conf << 'EOF'
-# Disable scdaemon's built-in CCID driver to prevent conflict with pcscd
-disable-ccid
-# Allow shared access to the card
-pcsc-shared
-EOF
+        echo "# Disable scdaemon's built-in CCID driver to prevent conflict with pcscd" > ~/.gnupg/scdaemon.conf
+        echo "disable-ccid" >> ~/.gnupg/scdaemon.conf
+        echo "# Allow shared access to the card" >> ~/.gnupg/scdaemon.conf
+        echo "pcsc-shared" >> ~/.gnupg/scdaemon.conf
         echo "Created ~/.gnupg/scdaemon.conf"
     fi
 


### PR DESCRIPTION
## Summary

Fixes `ujust` commands failing with:
```
error: Unknown start of token '.'
  ——▶ rocinante.just:23:43
   │
23 │ SSH_AUTH_SOCK=${XDG_RUNTIME_DIR}/ssh-agent.socket
   │                                           ^
```

## Problem

Just parses heredoc content as recipe syntax, not shell content. Special characters like `${}` and `.socket` get interpreted as just syntax tokens.

## Solution

Replace heredocs with multiple `echo` statements that just passes through to the shell.

## Test plan
- [x] `just --list -f rocinante.just` parses without errors
- [ ] `ujust setup-yubikey-ssh` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)