### PR TITLE
Use forked 1password integration script with XDG path fix

### DIFF
--- a/system_files/usr/share/ublue-os/just/rocinante.just
+++ b/system_files/usr/share/ublue-os/just/rocinante.just
@@ -210,41 +210,13 @@ setup-1password-browser:
         exit 0
     fi
 
-    # Ensure native-messaging-hosts directories exist for each browser
-    # The integration script expects these to exist
-    for browser in "${BROWSERS[@]}"; do
-        case "$browser" in
-            org.mozilla.firefox)
-                NMH_DIR="$HOME/.var/app/$browser/.mozilla/native-messaging-hosts"
-                ;;
-            com.google.Chrome|com.brave.Browser|org.chromium.Chromium)
-                # Chromium-based browsers use different paths
-                case "$browser" in
-                    com.google.Chrome)
-                        NMH_DIR="$HOME/.var/app/$browser/config/google-chrome/NativeMessagingHosts"
-                        ;;
-                    com.brave.Browser)
-                        NMH_DIR="$HOME/.var/app/$browser/config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
-                        ;;
-                    org.chromium.Chromium)
-                        NMH_DIR="$HOME/.var/app/$browser/config/chromium/NativeMessagingHosts"
-                        ;;
-                esac
-                ;;
-        esac
-        if [[ -n "${NMH_DIR:-}" ]] && [[ ! -d "$NMH_DIR" ]]; then
-            echo "Creating $NMH_DIR"
-            mkdir -p "$NMH_DIR"
-        fi
-    done
-
     # Clone and run integration script
     TEMP_DIR=$(mktemp -d)
     trap "rm -rf $TEMP_DIR" EXIT
     cd "$TEMP_DIR"
 
     echo "Downloading integration script..."
-    if git clone --depth 1 --quiet https://github.com/FlyinPancake/1password-flatpak-browser-integration; then
+    if git clone --depth 1 --quiet --branch fix-xdg-firefox-path https://github.com/allardvdb/1password-flatpak-browser-integration; then
         cd 1password-flatpak-browser-integration
         for browser in "${BROWSERS[@]}"; do
             echo ""


### PR DESCRIPTION
## Summary

- Switch to allardvdb fork of 1password-flatpak-browser-integration which includes fix for Firefox Flatpak using XDG-compliant paths (`config/mozilla/firefox` instead of `.mozilla/firefox`)
- Remove incorrect pre-creation of native-messaging-hosts directories (the integration script handles this correctly)

## Background

Newer Firefox Flatpak versions store profiles in XDG-compliant paths. The upstream script only searches 2 levels deep, missing the 3-level XDG structure.

## Test plan

- [ ] Test `ujust setup-1password-browser` on system with XDG-compliant Firefox (`config/mozilla/firefox/`)
- [ ] Verify integration works after browser restart

🤖 Generated with [Claude Code](https://claude.ai/code)