### PR TITLE
Add QEMU VM support packages for Incus

### DIFF
--- a/build/30-incus.sh
+++ b/build/30-incus.sh
@@ -2,7 +2,14 @@
 set -eoux pipefail
 
 echo "::group:: Install Incus"
-dnf5 install -y incus incus-tools
+dnf5 install -y \
+    incus \
+    incus-tools \
+    qemu-system-x86-core \
+    qemu-device-display-virtio-gpu \
+    qemu-device-display-virtio-vga \
+    edk2-ovmf \
+    swtpm
 echo "::endgroup::"
 
 echo "::group:: Configure Incus Services"


### PR DESCRIPTION
## Summary

- Add QEMU and related packages to `build/30-incus.sh` so Incus can run VMs (not just containers)
- Fixes `qemu-system-x86_64: executable file not found` when running `incus start <vm> --console=vga`
- Required after PR #34 switched from `bluefin-dx:stable` (which included QEMU) to `bluefin:stable`

### Packages added
| Package | Purpose |
|---|---|
| `qemu-system-x86-core` | Provides `qemu-system-x86_64` |
| `qemu-device-display-virtio-gpu` | virtio-gpu display device for `--console=vga` |
| `qemu-device-display-virtio-vga` | virtio-vga display device for `--console=vga` |
| `edk2-ovmf` | UEFI firmware for Windows VMs |
| `swtpm` | Software TPM emulator (needed by Windows 11) |

## Test plan

- [ ] `just build` succeeds
- [ ] After booting: `which qemu-system-x86_64` returns `/usr/bin/qemu-system-x86_64`
- [ ] `incus start desktop-win10 --console=vga` launches the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)