### PR TITLE
Add QEMU SPICE packages for Incus VM console

### DIFF
--- a/build/30-incus.sh
+++ b/build/30-incus.sh
@@ -8,6 +8,9 @@ dnf5 install -y \
     qemu-system-x86-core \
     qemu-device-display-virtio-gpu \
     qemu-device-display-virtio-vga \
+    qemu-ui-spice-core \
+    qemu-char-spice \
+    qemu-audio-spice \
     edk2-ovmf \
     swtpm
 echo "::endgroup::"


### PR DESCRIPTION
## Summary
- Adds `qemu-ui-spice-core`, `qemu-char-spice`, and `qemu-audio-spice` to the Incus build script
- Fixes `incus start --console=vga` failing with `exit status 1` because QEMU's `-spice` flag requires modules that weren't installed
- Enables audio passthrough via SPICE for Windows VMs

## Test plan
- [ ] `just build` completes successfully
- [ ] `incus start desktop-win10 --console=vga` launches without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)