### PR TITLE
Sync docs with sleep/firmware changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,16 @@ This is a custom Universal Blue / Bluefin Linux image that creates a personalize
 │   ├── 20-1password.sh       # 1Password desktop + CLI installation
 │   ├── 30-incus.sh           # Incus VM manager + QEMU/SPICE/VFIO
 │   ├── 40-rocm.sh            # AMD ROCm compute stack
+│   ├── 50-firmware.sh        # linux-firmware version override (Koji)
 │   └── copr-helpers.sh       # COPR helper functions (sourced by build scripts)
 ├── custom/                    # Custom files copied into the image at build time
 │   ├── brew/                  # Brewfiles for Homebrew packages
 │   │   └── default.Brewfile  # Default package list
+│   ├── systemd/
+│   │   └── system-sleep/
+│   │       └── 50-unmount-fuse.sh  # GVFS/FUSE unmount before suspend
+│   ├── udev/
+│   │   └── 99-disable-goodix-fingerprint.rules  # Disable fingerprint reader (S0ix)
 │   └── ujust/                 # Custom ujust recipes
 │       └── rocinante.just    # Rocinante-specific recipes (→ 60-custom.just)
 ├── disk_config/               # Disk image configurations (ISO, QCOW2, KDE/GNOME)
@@ -64,9 +70,11 @@ This means build scripts and custom files are never `COPY`'d into the final imag
   - Installs Homebrew via `rsync` from `/ctx/oci/brew/`
   - Copies Brewfiles to `/usr/share/ublue-os/homebrew/`
   - Concatenates `custom/ujust/*.just` into `/usr/share/ublue-os/just/60-custom.just`
+  - Copies udev rules from `custom/udev/` to `/etc/udev/rules.d/`
+  - Installs systemd sleep hooks from `custom/systemd/system-sleep/` to `/usr/lib/systemd/system-sleep/`
   - Installs dnf5 packages
   - Configures systemd units
-  - Calls additional numbered scripts (e.g., `20-1password.sh`)
+  - Calls additional numbered scripts (`20-1password.sh`, `30-incus.sh`, `40-rocm.sh`, `50-firmware.sh`)
 
 ### ujust recipes (60-custom.just)
 Bluefin's `00-entry.just` includes `import? "/usr/share/ublue-os/just/60-custom.just"`. The build script concatenates all `.just` files from `custom/ujust/` into this file, so recipes are automatically available via `ujust`.
@@ -78,7 +86,7 @@ Three variants are built from different base images:
 - **rocinante-nvidia**: `ghcr.io/ublue-os/bluefin-nvidia-open:stable` (GNOME + NVIDIA)
 - **rocinante-aurora**: `ghcr.io/ublue-os/aurora:stable` (KDE Plasma)
 
-All variants share the same build scripts and customizations. The Containerfile accepts a `BASE_IMAGE` build arg to select the variant. Developer tools are managed via Homebrew (@ublue-os/brew).
+All variants share the same build scripts and customizations. The Containerfile accepts `BASE_IMAGE` (variant selection) and `FIRMWARE_VERSION` (linux-firmware pin, default `20260309`) build args. Developer tools are managed via Homebrew (@ublue-os/brew).
 
 ## Key Customizations
 
@@ -96,6 +104,18 @@ All variants share the same build scripts and customizations. The Containerfile 
 - `brew-setup.service` runs on first boot to initialize Homebrew
 - `brew-update.timer` and `brew-upgrade.timer` keep packages current
 - Brewfiles in `custom/brew/` are copied to `/usr/share/ublue-os/homebrew/`
+
+### Firmware Override
+- `build/50-firmware.sh` pins `linux-firmware` to a known-good version from Koji
+- Fixes S0ix regression introduced in `linux-firmware-20260221` on AMD Strix Point
+- Version controlled via `FIRMWARE_VERSION` build arg in Containerfile
+
+### Sleep/Suspend Fixes (Framework 13 AMD)
+- Goodix fingerprint reader disabled via udev rule (`custom/udev/99-disable-goodix-fingerprint.rules`)
+- GVFS/FUSE mounts lazy-unmounted before suspend (`custom/systemd/system-sleep/50-unmount-fuse.sh`)
+- Machine-specific fixes applied via `ujust fix-sleep` (kernel params, wakeup source management)
+- Diagnostics via `ujust diagnose-sleep`
+- Details: `docs/amdgpu-strix-point-gpu-hang.md`
 
 ### System Configuration
 - Custom package installations via dnf5

--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ ujust first-run
 Individual recipes:
 - `ujust setup-1password-browser` — Flatpak browser integration
 - `ujust setup-yubikey-ssh` — YubiKey SSH authentication
+- `ujust enable-yubikey-gpg` — Prepare shell for GPG operations with YubiKey 5
 - `ujust toggle-suspend` — Disable suspend for remote access
 - `ujust setup-gpu-passthrough` — IOMMU + Incus GPU passthrough
 - `ujust configure-yubikey-pam` — YubiKey PAM authentication
+- `ujust setup-borgmatic` — Borgmatic backups to BorgBase
 - `ujust fix-amdgpu` — AMD GPU workarounds (Framework laptops)
+- `ujust fix-sleep` — Fix S0ix sleep issues (Framework 13 AMD)
+- `ujust diagnose-sleep` — Diagnose sleep/suspend issues
 
 ## What's included on top of vanilla Bluefin / Aurora
 
@@ -41,7 +45,9 @@ Individual recipes:
 | virt-viewer | SPICE client for `incus console --type=vga` |
 | ROCm | AMD GPU compute stack |
 | nvidia-container-toolkit | NVIDIA variant only |
-| Custom ujust recipes | YubiKey, 1Password, GPU passthrough, suspend toggle |
+| linux-firmware override | Pins known-good firmware version (S0ix regression fix) |
+| Sleep/suspend fixes | Udev rule + systemd-sleep hook for S0ix on Framework 13 AMD |
+| Custom ujust recipes | YubiKey, 1Password, GPU passthrough, sleep, borgmatic, and more |
 
 ## Project Structure
 
@@ -52,10 +58,13 @@ Individual recipes:
 │   ├── 20-1password.sh      # 1Password installation
 │   ├── 30-incus.sh          # Incus + QEMU/SPICE/VFIO
 │   ├── 40-rocm.sh           # AMD ROCm compute stack
+│   ├── 50-firmware.sh       # linux-firmware version override (Koji)
 │   └── copr-helpers.sh      # COPR helper functions
 ├── custom/                   # Custom files copied into the image
 │   ├── brew/                 # Brewfiles for Homebrew packages
 │   │   └── default.Brewfile
+│   ├── systemd/system-sleep/ # Systemd sleep hooks (→ /usr/lib/systemd/system-sleep/)
+│   ├── udev/                 # Udev rules (→ /etc/udev/rules.d/)
 │   └── ujust/                # Custom ujust recipes (→ 60-custom.just)
 │       └── rocinante.just
 ├── Containerfile             # Container build definition (ctx-stage pattern)

--- a/docs/amdgpu-strix-point-gpu-hang.md
+++ b/docs/amdgpu-strix-point-gpu-hang.md
@@ -42,7 +42,13 @@ This is a known upstream bug in the `amdgpu` driver affecting Strix Point GPUs. 
 
 ## Workarounds
 
-These are machine-specific kernel parameters, not baked into the rocinante image. Apply them on the affected machine with `rpm-ostree kargs`:
+These are machine-specific kernel parameters, not baked into the rocinante image. The recommended way to apply them is:
+
+```bash
+ujust fix-amdgpu
+```
+
+This automatically applies the parameters below and prompts for a reboot. For manual control, use `rpm-ostree kargs`:
 
 ### Disable Panel Self Refresh (PSR)
 

--- a/docs/yubikey-1password-authentication.md
+++ b/docs/yubikey-1password-authentication.md
@@ -31,14 +31,17 @@ This provides the best of both worlds: full YubiKey functionality + convenient b
 
 ### 1. Prerequisites
 
+On Fedora Atomic (Bluefin/Aurora), most of these packages are already in the base image. If any are missing, layer them with `rpm-ostree`:
+
 ```bash
-# Fedora/Bluefin packages
-sudo dnf install -y \
-    pam-u2f \
-    fprintd \
-    fprintd-pam \
-    yubikey-manager \
-    yubikey-manager-qt
+rpm-ostree install pam-u2f fprintd fprintd-pam yubikey-manager
+systemctl reboot
+```
+
+Or on the rocinante image, use the automated recipe which handles PAM configuration:
+
+```bash
+ujust configure-yubikey-pam
 ```
 
 ### 2. Configure Fingerprint Scanner
@@ -240,5 +243,5 @@ While it doesn't match macOS's 14-day persistence, it significantly reduces pass
 
 ---
 
-*Last updated: October 2025*
-*Tested on: Bluefin Linux (Fedora 40 base)*
+*Last updated: March 2026*
+*Tested on: Bluefin Linux (Fedora 43 base)*


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add `build/50-firmware.sh`, `custom/udev/`, `custom/systemd/` to project tree; update "how build scripts work" with udev/sleep hook steps; add Firmware Override and Sleep/Suspend Fixes sections; mention `FIRMWARE_VERSION` build arg
- **README.md**: Add 4 missing ujust recipes (`enable-yubikey-gpg`, `setup-borgmatic`, `fix-sleep`, `diagnose-sleep`); update project structure tree; add firmware override and sleep fixes to "what's included" table
- **amdgpu doc**: Add `ujust fix-amdgpu` as recommended way to apply GPU workarounds
- **yubikey doc**: Replace `sudo dnf install` with `rpm-ostree install` for Fedora Atomic; mention `ujust configure-yubikey-pam`; update "tested on" from Fedora 40 to 43

## Test plan
- [ ] All markdown renders correctly on GitHub
- [ ] No broken internal links
- [ ] Project structure trees match actual repo contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)