### PR TITLE
Add httpie, lazygit, nvtop to default Brewfile

### DIFF
--- a/custom/brew/default.Brewfile
+++ b/custom/brew/default.Brewfile
@@ -2,6 +2,9 @@
 # These packages are installed via Homebrew on first boot (brew-setup.service)
 
 # Core CLI tools (always installed)
-brew "fzf"
-brew "jq"
 brew "btop"
+brew "fzf"
+brew "httpie"
+brew "jq"
+brew "lazygit"
+brew "nvtop"


### PR DESCRIPTION
## Summary
- Add `httpie` (modern HTTP client), `lazygit` (terminal git UI), `nvtop` (GPU process monitor)
- Sort package list alphabetically (moves `btop` above `fzf`)

## Test plan
- [ ] Brewfile validation CI passes
- [ ] `brew bundle --file=custom/brew/default.Brewfile` installs all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)