### PR TITLE
Fix WiFi, Bluetooth, and sleep: add missing firmware sub-packages

### DIFF
--- a/build/50-firmware.sh
+++ b/build/50-firmware.sh
@@ -18,7 +18,10 @@ dnf5 -y install \
     "${KOJI_BASE}/linux-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
     "${KOJI_BASE}/linux-firmware-whence-${FIRMWARE_RELEASE}.noarch.rpm" \
     "${KOJI_BASE}/amd-gpu-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/amd-ucode-firmware-${FIRMWARE_RELEASE}.noarch.rpm"
+    "${KOJI_BASE}/amd-ucode-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
+    "${KOJI_BASE}/mediatek-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
+    "${KOJI_BASE}/realtek-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
+    "${KOJI_BASE}/cirrus-audio-firmware-${FIRMWARE_RELEASE}.noarch.rpm"
 
 echo "Installed firmware version:"
 rpm -q linux-firmware


### PR DESCRIPTION
## Summary
- The firmware pin script (`build/50-firmware.sh`) removed all `linux-firmware*` packages but only reinstalled AMD-specific ones
- This dropped `mediatek-firmware` (MT7925 WiFi/BT), `realtek-firmware` (USB 2.5G ethernet), and `cirrus-audio-firmware` (audio codec)
- Result: WiFi broken, Bluetooth broken, suspend fails with `mt7925e` timeout (`-110`)
- Fix: add the three missing firmware sub-packages to the Koji install list

## Test plan
- [ ] Build completes successfully with all firmware packages installed
- [ ] WiFi works after reboot into new image
- [ ] Bluetooth works after reboot
- [ ] `sudo rtcwake -m freeze -s 10` completes without `write error`
- [ ] `sudo cat /sys/kernel/debug/amd_pmc/s0ix_stats` shows non-zero Success/Residency

🤖 Generated with [Claude Code](https://claude.com/claude-code)