### PR TITLE
Add stable/testing/latest release streams

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,6 @@ jobs:
           tags: |
             type=raw,value=${{ env.DEFAULT_TAG }}
             type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
-            type=raw,value={{date 'YYYYMMDD'}}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -17,6 +17,7 @@ jobs:
         package:
           - rocinante
           - rocinante-nvidia
+          - rocinante-aurora
     steps:
       - name: Delete Images Older Than 90 Days
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
@@ -25,5 +26,5 @@ jobs:
           packages: ${{ matrix.package }}
           older-than: 90 days
           delete-orphaned-images: true
-          keep-n-tagged: 7
+          keep-n-tagged: 14
           keep-n-untagged: 7

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,95 @@
+---
+name: Promote release stream
+on:
+  release:
+    types: [published]
+
+env:
+  IMAGE_REGISTRY: ghcr.io/allardvdb
+
+jobs:
+  promote:
+    name: Promote ${{ matrix.image_name }} to ${{ github.event.release.prerelease && 'testing' || 'stable' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image_name:
+          - rocinante
+          - rocinante-nvidia
+          - rocinante-aurora
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Determine stream and date
+        id: meta
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            STREAM="testing"
+          else
+            STREAM="stable"
+          fi
+
+          # Extract date from tag name (e.g., stable-20260311 → 20260311)
+          DATE="${TAG_NAME##*-}"
+          if [[ ! "$DATE" =~ ^[0-9]{8}$ ]]; then
+            echo "::error::Tag name must end with a date (YYYYMMDD), got: $TAG_NAME"
+            exit 1
+          fi
+
+          echo "stream=$STREAM" >> "$GITHUB_OUTPUT"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "Promoting latest.$DATE → $STREAM / $STREAM.$DATE"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Retag image
+        env:
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ matrix.image_name }}
+          STREAM: ${{ steps.meta.outputs.stream }}
+          DATE: ${{ steps.meta.outputs.date }}
+        run: |
+          SOURCE="docker://${IMAGE}:latest.${DATE}"
+          echo "Source: $SOURCE"
+
+          # Copy to mutable stream tag
+          skopeo copy --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}"
+          echo "Tagged ${IMAGE}:${STREAM}"
+
+          # Copy to immutable date-pinned stream tag
+          skopeo copy --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}.${DATE}"
+          echo "Tagged ${IMAGE}:${STREAM}.${DATE}"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: 'v2.6.1'
+
+      - name: Sign promoted tags
+        env:
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ matrix.image_name }}
+          STREAM: ${{ steps.meta.outputs.stream }}
+          DATE: ${{ steps.meta.outputs.date }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+        run: |
+          for tag in "${STREAM}" "${STREAM}.${DATE}"; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}:${tag}"
+            echo "Signed ${IMAGE}:${tag}"
+          done

--- a/README.md
+++ b/README.md
@@ -17,6 +17,40 @@ sudo bootc switch ghcr.io/allardvdb/rocinante-nvidia
 sudo bootc switch ghcr.io/allardvdb/rocinante-aurora
 ```
 
+## Release Streams
+
+Images are published in three release streams:
+
+| Stream | Tag | Purpose |
+|--------|-----|---------|
+| `stable` | `:stable` | Daily drivers — manually promoted via GitHub Release |
+| `testing` | `:testing` | Pre-release soak — promoted via GitHub pre-release |
+| `latest` | `:latest` | Bleeding edge — every push to main and daily cron |
+
+Each stream also has date-pinned tags (e.g., `:stable.20260311`) for rollback.
+
+### Switching streams
+
+```bash
+ujust switch-stream
+```
+
+Or manually:
+
+```bash
+sudo bootc switch ghcr.io/allardvdb/rocinante:stable --enforce-container-sigpolicy
+```
+
+### Image references
+
+```
+ghcr.io/allardvdb/rocinante:stable
+ghcr.io/allardvdb/rocinante-nvidia:stable
+ghcr.io/allardvdb/rocinante-aurora:stable
+```
+
+Replace `:stable` with `:testing` or `:latest` as needed.
+
 ## First-Time Setup
 
 ```bash
@@ -24,6 +58,7 @@ ujust first-run
 ```
 
 Individual recipes:
+- `ujust switch-stream` — Switch between stable/testing/latest release streams
 - `ujust setup-1password-browser` — Flatpak browser integration
 - `ujust setup-yubikey-ssh` — YubiKey SSH authentication
 - `ujust enable-yubikey-gpg` — Prepare shell for GPG operations with YubiKey 5

--- a/custom/ujust/rocinante.just
+++ b/custom/ujust/rocinante.just
@@ -1,5 +1,88 @@
 # Rocinante custom ujust recipes
 
+# Switch between release streams (stable, testing, latest)
+[group('Rocinante')]
+switch-stream:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Terminal formatting
+    b=$(tput bold 2>/dev/null) || b=""
+    n=$(tput sgr0 2>/dev/null) || n=""
+    green=$(tput setaf 2 2>/dev/null) || green=""
+
+    # Detect current image and tag from bootc status
+    BOOTC_JSON=$(bootc status --json 2>/dev/null)
+    CURRENT_IMAGE=$(echo "$BOOTC_JSON" | jq -r '.spec.image.image // empty')
+    if [[ -z "$CURRENT_IMAGE" ]]; then
+        echo "Error: Could not detect current image from bootc status"
+        exit 1
+    fi
+
+    # Split into base and tag
+    IMAGE_BASE="${CURRENT_IMAGE%%:*}"
+    CURRENT_TAG="${CURRENT_IMAGE##*:}"
+    if [[ "$CURRENT_TAG" == "$CURRENT_IMAGE" ]]; then
+        CURRENT_TAG="latest"
+    fi
+
+    # Determine current stream from tag
+    CURRENT_STREAM="$CURRENT_TAG"
+    # Strip date suffix if present (e.g., stable.20260311 → stable)
+    CURRENT_STREAM="${CURRENT_STREAM%%.*}"
+
+    echo "${b}Release Stream Switcher${n}"
+    echo ""
+    echo "  Image:   ${IMAGE_BASE}"
+    echo "  Current: ${CURRENT_TAG} (stream: ${CURRENT_STREAM})"
+    echo ""
+
+    # Present stream menu
+    STREAMS=("stable" "testing" "latest")
+    if command -v gum &> /dev/null; then
+        SELECTED=$(gum choose --header "Select stream:" "${STREAMS[@]}")
+    else
+        echo "Select stream:"
+        echo "  1) stable   — Daily drivers, manually promoted"
+        echo "  2) testing  — Pre-release soak"
+        echo "  3) latest   — Bleeding edge, every build"
+        echo ""
+        read -p "Choice [1-3]: " choice
+        case "$choice" in
+            1) SELECTED="stable" ;;
+            2) SELECTED="testing" ;;
+            3) SELECTED="latest" ;;
+            *) echo "Invalid choice"; exit 1 ;;
+        esac
+    fi
+
+    if [[ -z "$SELECTED" ]]; then
+        exit 0
+    fi
+
+    # No-op guard
+    if [[ "$CURRENT_STREAM" == "$SELECTED" ]]; then
+        echo ""
+        echo "${green}Already on the ${b}${SELECTED}${n}${green} stream — nothing to do.${n}"
+        exit 0
+    fi
+
+    TARGET="${IMAGE_BASE}:${SELECTED}"
+    echo ""
+    echo "Switching: ${CURRENT_TAG} → ${b}${SELECTED}${n}"
+    echo "  ${TARGET}"
+    echo ""
+    read -p "Continue? [Y/n]: " confirm
+    if [[ "$confirm" =~ ^[Nn]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+
+    sudo bootc switch "${TARGET}" --enforce-container-sigpolicy
+
+    echo ""
+    echo "${green}${b}Switched to ${SELECTED} stream.${n}"
+    echo "Reboot to apply: ${b}systemctl reboot${n}"
+
 # Configure YubiKey for SSH and git signing using FIDO2 (works with Bio and 5)
 [group('Rocinante')]
 setup-yubikey-ssh:


### PR DESCRIPTION
## Summary

- Introduces three release streams (`stable`, `testing`, `latest`) with GitHub Release-based promotion, following Universal Blue conventions
- Adds `promote.yml` workflow: creating a GitHub Release (pre-release → testing, full → stable) retags images via `skopeo copy` and signs with cosign across all 3 variants
- Adds `ujust switch-stream` interactive recipe for switching streams on running systems
- Removes redundant bare `YYYYMMDD` tag from build.yml, fixes missing `rocinante-aurora` in clean.yml matrix, bumps `keep-n-tagged` to 14

## Test plan

- [ ] Push branch → verify build.yml still produces `latest` and `latest.YYYYMMDD` tags (no bare `YYYYMMDD`)
- [ ] After merge, create test pre-release `testing-20260311` → verify all 3 variants get `:testing` and `:testing.20260311` tags on GHCR
- [ ] Create full release `stable-20260311` → verify `:stable` tags appear
- [ ] On a laptop, run `ujust switch-stream` → select `stable` → verify `bootc status` shows `:stable` after reboot
- [ ] Verify `cosign verify --key cosign.pub ghcr.io/allardvdb/rocinante:stable` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)