### PR TITLE
Fix promote workflow to preserve layer digests

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -69,12 +69,13 @@ jobs:
           SOURCE="docker://${IMAGE}:latest.${DATE}"
           echo "Source: $SOURCE"
 
-          # Copy to mutable stream tag
-          skopeo copy --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}"
+          # Copy to mutable stream tag (--all preserves manifests and layer digests
+          # so bootc recognizes shared layers and avoids re-downloading)
+          skopeo copy --all --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}"
           echo "Tagged ${IMAGE}:${STREAM}"
 
           # Copy to immutable date-pinned stream tag
-          skopeo copy --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}.${DATE}"
+          skopeo copy --all --retry-times 3 "$SOURCE" "docker://${IMAGE}:${STREAM}.${DATE}"
           echo "Tagged ${IMAGE}:${STREAM}.${DATE}"
 
       - name: Install Cosign


### PR DESCRIPTION
## Summary

- Add `--all` flag to `skopeo copy` commands in promote workflow to preserve original manifests and layer digests
- Without this, skopeo can transcode between Docker v2 and OCI formats, recompressing layers and changing digests
- This caused `bootc switch` to `:stable` to re-download ~1.2 GB of layers already present from `:latest.20260311`

## Test plan

- [ ] After merge, create a new release to re-promote `stable-20260319` (or delete/recreate `stable-20260311`)
- [ ] On a laptop already running `latest.YYYYMMDD`, `bootc switch` to `:stable` should show 0 new layers needed
- [ ] Verify `skopeo inspect` shows matching layer digests between `:latest.YYYYMMDD` and `:stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)