### PR TITLE
Fix firmware override to preserve all sub-packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,8 @@ All variants share the same build scripts and customizations. The Containerfile 
 - `build/50-firmware.sh` pins `linux-firmware` to a known-good version from Koji
 - Fixes S0ix regression introduced in `linux-firmware-20260221` on AMD Strix Point
 - Version controlled via `FIRMWARE_VERSION` build arg in Containerfile
+- Dynamically discovers ALL installed firmware sub-packages before removal and reinstalls them all at the pinned version, preserving firmware for all hardware (Intel WiFi, Broadcom, MediaTek, AMD, etc.)
+- Validates Koji URLs before removing packages to fail early on package renames or missing versions
 
 ### Sleep/Suspend Fixes (Framework 13 AMD)
 - Goodix fingerprint reader disabled via udev rule (`custom/udev/99-disable-goodix-fingerprint.rules`)

--- a/build/50-firmware.sh
+++ b/build/50-firmware.sh
@@ -4,24 +4,61 @@ set -eoux pipefail
 # Override linux-firmware to fix S0ix regression (linux-firmware-20260221 broke S0ix on Strix Point)
 # Follows the Bazzite pattern: pin firmware version via Koji RPMs
 # See: https://github.com/bazzite-org/bazzite/issues/4356
+#
+# This script dynamically discovers all installed linux-firmware sub-packages
+# and reinstalls them at the pinned version, so no firmware is lost regardless
+# of what hardware the image runs on.
 
 FIRMWARE_VERSION="${FIRMWARE_VERSION:-20260309}"
 FIRMWARE_RELEASE="${FIRMWARE_VERSION}-1.fc$(rpm -E %fedora)"
 KOJI_BASE="https://kojipkgs.fedoraproject.org/packages/linux-firmware/${FIRMWARE_VERSION}/1.fc$(rpm -E %fedora)/noarch"
 
 echo "::group:: Override linux-firmware to ${FIRMWARE_VERSION}"
+
+# Discover all currently installed linux-firmware sub-packages.
+# The glob catches linux-firmware and linux-firmware-whence directly.
+# The whatrequires query catches all sub-packages that depend on
+# linux-firmware-whence (and would be cascade-removed).
+mapfile -t INSTALLED_PKGS < <(
+    {
+        rpm -qa --qf '%{NAME}\n' 'linux-firmware*' 2>/dev/null || true
+        rpm -q --whatrequires linux-firmware-whence --qf '%{NAME}\n' 2>/dev/null || true
+    } | sort -u
+)
+
+if [[ ${#INSTALLED_PKGS[@]} -eq 0 ]]; then
+    echo "ERROR: No linux-firmware packages found in base image. Cannot proceed."
+    exit 1
+fi
+
+echo "Discovered ${#INSTALLED_PKGS[@]} firmware packages to reinstall:"
+printf '  %s\n' "${INSTALLED_PKGS[@]}"
+
+# Build Koji URL list for all discovered packages.
+KOJI_URLS=()
+for pkg in "${INSTALLED_PKGS[@]}"; do
+    KOJI_URLS+=("${KOJI_BASE}/${pkg}-${FIRMWARE_RELEASE}.noarch.rpm")
+done
+
+# Validate all URLs exist on Koji BEFORE removing anything.
+# This catches package renames or missing packages at the pinned version
+# without leaving the image in a broken state.
+echo "Validating ${#KOJI_URLS[@]} Koji URLs..."
+for url in "${KOJI_URLS[@]}"; do
+    if ! curl -sf -I --max-time 10 --retry 2 "$url" > /dev/null; then
+        echo "ERROR: Package not found on Koji: ${url}"
+        echo "The pinned FIRMWARE_VERSION=${FIRMWARE_VERSION} may not have this package."
+        echo "Check Koji for available sub-packages at this version."
+        exit 1
+    fi
+done
+echo "All URLs validated."
+
 echo "Removing existing linux-firmware packages..."
-dnf5 -y remove linux-firmware\* || echo "WARNING: dnf5 remove exited $?, continuing..."
+dnf5 -y remove linux-firmware\* || { rc=$?; echo "WARNING: dnf5 remove exited ${rc}, continuing..."; }
 
 echo "Installing linux-firmware ${FIRMWARE_RELEASE} from Koji..."
-dnf5 -y install \
-    "${KOJI_BASE}/linux-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/linux-firmware-whence-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/amd-gpu-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/amd-ucode-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/mediatek-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/realtek-firmware-${FIRMWARE_RELEASE}.noarch.rpm" \
-    "${KOJI_BASE}/cirrus-audio-firmware-${FIRMWARE_RELEASE}.noarch.rpm"
+dnf5 -y install "${KOJI_URLS[@]}"
 
 echo "Installed firmware version:"
 rpm -q linux-firmware


### PR DESCRIPTION
## Summary

- Replaced static 7-package reinstall list in `build/50-firmware.sh` with dynamic discovery of ALL installed firmware sub-packages
- The old script removed all linux-firmware packages via cascade but only reinstalled 7 of 21, losing WiFi/BT firmware (mt7xxx-firmware, iwlwifi-*, brcmfmac-firmware, etc.)
- Now validates Koji URLs before the destructive remove to fail early on package renames or missing versions
- Updated AGENTS.md firmware documentation

## Root cause

`dnf5 -y remove linux-firmware\*` triggers cascade removal of all 21 sub-packages via `linux-firmware-whence` dependency. Only 7 were reinstalled. Additionally, the script used `mediatek-firmware` (wrong package) instead of `mt7xxx-firmware`.

## Test plan

- [ ] CI build succeeds with all firmware packages reinstalled
- [ ] Verify WiFi works on Framework 13 AMD (MT7925 via mt7xxx-firmware)
- [ ] Verify Bluetooth works on Framework 13 AMD
- [ ] Verify WiFi on any Intel WiFi equipped machines (iwlwifi-* firmware)
- [ ] Verify `rpm -qa '*-firmware*' | wc -l` shows same count as base image

🤖 Generated with [Claude Code](https://claude.com/claude-code)