### PR TITLE
Fix ujust switch-stream recipe/alias conflict

### DIFF
--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -15,6 +15,8 @@ echo "::group:: Copy Custom Files"
 # Brewfiles
 mkdir -p /usr/share/ublue-os/homebrew/
 cp /ctx/custom/brew/*.Brewfile /usr/share/ublue-os/homebrew/
+# Remove upstream switch-stream aliases that conflict with our custom recipe
+sed -i '/^alias switch-stream/d' /usr/share/ublue-os/just/system.just
 # Ujust recipes → 60-custom.just (bluefin's 00-entry.just imports this)
 find /ctx/custom/ujust -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >> /usr/share/ublue-os/just/60-custom.just
 # Udev rules


### PR DESCRIPTION
## Summary

- Upstream bluefin `system.just` defines `alias switch-stream := rebase-helper`, which conflicts with our custom `switch-stream` recipe in `rocinante.just`
- `just`'s `allow-duplicate-recipes` permits duplicate recipes but **not** a recipe redefining an alias, causing **all** `ujust` commands to fail with: `error: Recipe 'switch-stream' defined on line 7 is redefined as an alias on line 93`
- Strips the upstream `switch-stream` aliases during container build so our interactive stream-switcher recipe takes precedence

## Test plan

- [ ] Build the container image and verify no `just` errors
- [ ] Run `ujust --list` inside the built image — should list all recipes without errors
- [ ] Run `ujust switch-stream` — should show the interactive stream selector
- [ ] Run `ujust update` — should work without alias conflict errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)