### PR TITLE
Fix delayed-hibernate hook parsing 'us:' label from systemd-analyze

### DIFF
--- a/custom/ujust/rocinante.just
+++ b/custom/ujust/rocinante.just
@@ -1801,9 +1801,10 @@ setup-hibernate:
                 }
             done
         fi
-        # Convert systemd timespan to seconds (LC_ALL=C pins the μs label
-        # against locale-dependent output) and arm RTC
-        US=$(LC_ALL=C systemd-analyze timespan "$DELAY" 2>/dev/null | awk '/μs:/ {print $2}')
+        # Convert systemd timespan to microseconds then seconds, and arm RTC.
+        # Match both "us:" (current systemd) and "μs:" (older systemd) labels;
+        # LC_ALL=C pins label wording against locale-dependent output.
+        US=$(LC_ALL=C systemd-analyze timespan "$DELAY" 2>/dev/null | awk '$1 == "us:" || $1 == "μs:" {print $2}')
         [[ -n "$US" ]] || { logger -t delayed-hibernate "invalid delay '$DELAY'"; exit 0; }
         SECS=$((US / 1000000))
         [[ "$SECS" -gt 0 ]] || exit 0


### PR DESCRIPTION
## Summary

- Fix the delayed-hibernate sleep hook installed by \`ujust setup-hibernate\`. Its awk pattern was matching \`μs:\` (Unicode mu) against the label emitted by \`systemd-analyze timespan\`, but current systemd emits \`us:\` (ASCII). Result: the hook silently failed to arm the RTC wakealarm and logged \`invalid delay '5m'\`, so closing the lid produced plain suspend with no hibernate transition.
- Match both \`us:\` and \`μs:\` so the hook keeps working on older systemd versions that still use the Unicode label.
- Update the nearby comment to reflect what the label actually is.

## Bug repro

On a rocinante install where \`ujust setup-hibernate\` has run, close the lid on battery. Expected: suspend-then-hibernate after the configured delay. Actual: plain suspend, no hibernate.

From the journal at the time of my test:
\`\`\`
systemd-sleep[9200]: Performing sleep operation 'suspend'...
kernel: PM: suspend entry (s2idle)
...9 minutes later, wake, no hibernate attempt...
\`\`\`

Manually invoking \`/etc/systemd/system-sleep/10-delayed-hibernate.sh pre suspend\` logged:
\`\`\`
delayed-hibernate: invalid delay '5m'
\`\`\`

Direct check of \`systemd-analyze timespan 5m\` output:
\`\`\`
Original: 5m
      us: 300000000
   Human: 5min
\`\`\`

The label is \`us:\` (bytes \`75 73\`), not \`μs:\` (bytes \`ce bc 73\`).

## Fix

Field-based awk match on both labels:

\`\`\`diff
-US=\$(LC_ALL=C systemd-analyze timespan "\$DELAY" 2>/dev/null | awk '/μs:/ {print \$2}')
+US=\$(LC_ALL=C systemd-analyze timespan "\$DELAY" 2>/dev/null | awk '\$1 == "us:" || \$1 == "μs:" {print \$2}')
\`\`\`

Field-based matching is slightly safer than the regex form because it only matches on the label column.

## Verification

Applied the same fix to the on-disk installed hook via \`sed\` and reran it manually:

\`\`\`
$ sudo /etc/systemd/system-sleep/10-delayed-hibernate.sh pre suspend
$ journalctl -t delayed-hibernate --since '1 minute ago'
Apr 08 17:36:36 tool2 delayed-hibernate[18406]: armed RTC alarm for 5m (300s)
\`\`\`

And \`/sys/class/rtc/rtc0/wakealarm\` contained a unix timestamp exactly 300 seconds in the future.

Disarmed the alarm afterwards to avoid an unwanted hibernate.

## Test plan

- [ ] \`ujust setup-hibernate\` to re-install the hook from the fixed source
- [ ] Close lid on battery, confirm suspend-then-hibernate actually hibernates after the configured delay
- [ ] Confirm close lid on AC with \`hibernate-on-ac=no\` still does plain suspend (no regression on AC-skip path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)