### PR TITLE
Pin kernel to 6.17.12 to avoid AMD MES hang on Strix Point

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
+            KERNEL_PIN=6.17.12-300.fc43.x86_64
           oci: false
 
       # Rechunk is a script that we use on Universal Blue to make sure there isnt a single huge layer when your image gets published.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This is a custom Universal Blue / Bluefin Linux image that creates a personalize
 │       ├── validate-justfiles.yml   # Justfile format check on PRs
 │       └── validate-shellcheck.yml  # Shellcheck on build/*.sh on PRs
 ├── build/                     # Build scripts (numbered, run during image build)
+│   ├── 05-kernel-pin.sh      # Kernel pin (avoids AMD MES hang on Strix Point)
 │   ├── 10-build.sh           # Main orchestrator (brew, packages, ujust, systemd)
 │   ├── 20-1password.sh       # 1Password desktop + CLI installation
 │   ├── 30-incus.sh           # Incus VM manager + QEMU/SPICE/VFIO
@@ -67,6 +68,7 @@ This means build scripts and custom files are never `COPY`'d into the final imag
 
 ### How build scripts work
 - `build/10-build.sh` is the main orchestrator:
+  - Calls `05-kernel-pin.sh` first (swaps base image kernel + kmods to the pinned version)
   - Installs Homebrew via `rsync` from `/ctx/oci/brew/`
   - Copies Brewfiles to `/usr/share/ublue-os/homebrew/`
   - Concatenates `custom/ujust/*.just` into `/usr/share/ublue-os/just/60-custom.just`
@@ -104,6 +106,15 @@ All variants share the same build scripts and customizations. The Containerfile 
 - `brew-setup.service` runs on first boot to initialize Homebrew
 - `brew-update.timer` and `brew-upgrade.timer` keep packages current
 - Brewfiles in `custom/brew/` are copied to `/usr/share/ublue-os/homebrew/`
+
+### Kernel Pin
+- `build/05-kernel-pin.sh` pins the kernel to a known-good version built by ublue-os/akmods
+- Avoids the AMD MES scheduler hang on Strix Point / gfx1150 (Framework 13 AMD) introduced by kernels 6.18.x and 6.19.x — see `docs/amdgpu-strix-point-gpu-hang.md`
+- Version controlled via `KERNEL_PIN` build arg (default `6.17.12-300.fc43.x86_64`) in Containerfile and `.github/workflows/build.yml`
+- Kernel + matching kmod RPMs are bind-mounted into the build from `ghcr.io/ublue-os/akmods:coreos-stable-43-<KERNEL_PIN>`, `akmods-zfs:...`, and (for nvidia variant) `akmods-nvidia-open:...` — no files are baked into intermediate layers
+- Erases the base image's kernel + kmod set with `rpm --erase --nodeps`, reinstalls from the akmods bind mounts, locks with `dnf5 versionlock`
+- Mechanism closely ports the kernel-swap pattern from [bluefin PR #4187](https://github.com/ublue-os/bluefin/pull/4187)
+- Removable in a single revert when kernel 7.0+ lands upstream or when bluefin re-pins. See exit criterion in `docs/amdgpu-strix-point-gpu-hang.md`.
 
 ### Firmware Override
 - `build/50-firmware.sh` pins `linux-firmware` to a known-good version from Koji

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,15 @@
 ARG BASE_IMAGE=ghcr.io/ublue-os/bluefin:stable
+# Pinned kernel to avoid AMD MES scheduler hang on Strix Point / gfx1150.
+# See docs/amdgpu-strix-point-gpu-hang.md and build/05-kernel-pin.sh.
+ARG KERNEL_PIN=6.17.12-300.fc43.x86_64
+ARG AKMODS_FLAVOR=coreos-stable-43
+
+# Akmods sources for the pinned kernel. These stages are only pulled to
+# provide the kernel + matching kmod RPMs via bind mounts during the RUN
+# step; nothing from them ends up in the final image layer.
+FROM ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${KERNEL_PIN} AS akmods-src
+FROM ghcr.io/ublue-os/akmods-zfs:${AKMODS_FLAVOR}-${KERNEL_PIN} AS akmods-zfs-src
+FROM ghcr.io/ublue-os/akmods-nvidia-open:${AKMODS_FLAVOR}-${KERNEL_PIN} AS akmods-nvidia-open-src
 
 FROM scratch AS ctx
 COPY build /build
@@ -13,11 +24,18 @@ FROM ${BASE_IMAGE}
 # rocinante-nvidia: ghcr.io/ublue-os/bluefin-nvidia-open:stable
 # rocinante-aurora: ghcr.io/ublue-os/aurora:stable
 
+ARG BASE_IMAGE
+ARG KERNEL_PIN
 ARG FIRMWARE_VERSION=20260309
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=bind,from=akmods-src,source=/,target=/akmods-src \
+    --mount=type=bind,from=akmods-zfs-src,source=/,target=/akmods-zfs-src \
+    --mount=type=bind,from=akmods-nvidia-open-src,source=/,target=/akmods-nvidia-open-src \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
+    BASE_IMAGE=${BASE_IMAGE} \
+    KERNEL_PIN=${KERNEL_PIN} \
     FIRMWARE_VERSION=${FIRMWARE_VERSION} \
     /ctx/build/10-build.sh
 

--- a/build/05-kernel-pin.sh
+++ b/build/05-kernel-pin.sh
@@ -66,6 +66,23 @@ mapfile -t OLD_KMODS < <(
 echo "Installed kmods to erase:"
 printf '  %s\n' "${OLD_KMODS[@]}"
 
+# Discover currently installed ZFS userspace packages. These must be
+# swapped as a set together with kmod-zfs: the akmods-zfs container is
+# a snapshot bundled with the pinned kernel, so the ZFS version inside
+# it may differ from whatever the base image currently has (e.g.
+# akmods-zfs for 6.17.12 ships ZFS 2.3.5, but bluefin:stable has since
+# upgraded to 2.3.6). If we leave the old userspace in place, dnf5
+# fails to resolve the transaction with "cannot install both
+# libnvpair3-<old> and libnvpair3-<new>" style conflicts.
+mapfile -t OLD_ZFS < <(
+    rpm -qa --qf '%{NAME}\n' \
+        'zfs' 'zfs-dracut' 'zfs-test' \
+        'libnvpair*' 'libuutil*' 'libzfs*' 'libzpool*' \
+        'python3-pyzfs' 2>/dev/null | sort -u
+)
+echo "Installed ZFS userspace packages to erase:"
+printf '  %s\n' "${OLD_ZFS[@]}"
+
 # Erase the old kernel (--nodeps because kmods still depend on it; we'll
 # reinstall matching versions in a moment).
 if [[ ${#OLD_KERNEL_PKGS[@]} -gt 0 ]]; then
@@ -76,6 +93,12 @@ fi
 # them; versions are about to be replaced).
 if [[ ${#OLD_KMODS[@]} -gt 0 ]]; then
     rpm --erase --nodeps "${OLD_KMODS[@]}" || true
+fi
+
+# Erase the old ZFS userspace so the matching 2.x versions from
+# akmods-zfs can install cleanly.
+if [[ ${#OLD_ZFS[@]} -gt 0 ]]; then
+    rpm --erase --nodeps "${OLD_ZFS[@]}" || true
 fi
 
 # Clear stale module trees left behind by the erased packages.
@@ -139,16 +162,20 @@ dnf5 -y install \
     "${AKMODS_SRC}"/rpms/kmods/kmod-v4l2loopback-*.rpm \
     "${AKMODS_SRC}"/rpms/ublue-os/ublue-os-akmods-addons-*.rpm
 
-# Install matching ZFS kmod + userspace libs built against the pinned kernel.
-# Bluefin's ZFS_RPMS glob pattern (PR #4187) — match version-number suffixes
-# to avoid pulling in debug/devel subpackages from /rpms/kmods/zfs/{debug,devel}/.
+# Install matching ZFS kmod + userspace built against the pinned kernel.
+# Mirror bluefin PR #4187's ZFS_RPMS list (version-number suffixes avoid
+# pulling in debug/devel subpackages from /rpms/kmods/zfs/{debug,devel}/),
+# plus `zfs` (the main userspace meta at the zfs/ top level) and
+# zfs-dracut (which lives under zfs/other/).
 dnf5 -y install \
     "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/kmod-zfs-"${KERNEL_PIN}"-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/zfs-[0-9]*.rpm \
     "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libnvpair[0-9]-*.rpm \
     "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libuutil[0-9]-*.rpm \
     "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libzfs[0-9]-*.rpm \
     "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libzpool[0-9]-*.rpm \
-    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/python3-pyzfs-*.rpm
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/python3-pyzfs-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/other/zfs-dracut-*.rpm
 
 # Nvidia-open variant: restore kmod-nvidia built against the pinned kernel.
 # Userspace nvidia libs come from the bluefin-nvidia-open base image and

--- a/build/05-kernel-pin.sh
+++ b/build/05-kernel-pin.sh
@@ -81,23 +81,46 @@ fi
 # Clear stale module trees left behind by the erased packages.
 rm -rf /usr/lib/modules/*
 
-# Shim out the kernel-install.d plugins that fire from kernel-core's
-# %posttrans scriptlet. Inside a buildah container environment,
-# `05-rpmostree.install` calls `rpm-ostree kernel-install` which tries
-# to regenerate the initramfs via dracut and fails with "Invalid cross-
-# device link". The shim replaces both plugins with /bin/sh true stubs
-# for the duration of the dnf5 install, then restores them. initramfs
-# gets regenerated on the running system at first boot anyway, so
-# skipping it during the image build is safe.
+# Move every kernel-install.d plugin aside for the duration of the
+# dnf5 transaction. The kernel-core and kernel-modules %posttrans
+# scriptlets run /usr/bin/kernel-install, which invokes each
+# executable plugin under /usr/lib/kernel/install.d/. In a buildah
+# container build environment several of those plugins fail loudly
+# and take the transaction with them:
 #
-# Pattern cribbed verbatim from bazzite's build_files/install-kernel.
-pushd /usr/lib/kernel/install.d >/dev/null
-mv 05-rpmostree.install 05-rpmostree.install.bak
-mv 50-dracut.install 50-dracut.install.bak
-printf '%s\n' '#!/bin/sh' 'exit 0' > 05-rpmostree.install
-printf '%s\n' '#!/bin/sh' 'exit 0' > 50-dracut.install
-chmod +x 05-rpmostree.install 50-dracut.install
-popd >/dev/null
+#   - 05-rpmostree.install  -> tries to run rpm-ostree + dracut to
+#     regenerate the initramfs; dracut fails with "Invalid cross-
+#     device link" inside the overlayfs build mount
+#   - 20-grub.install       -> grub2-probe can't canonicalise 'overlay',
+#     grub2-editenv can't write /boot/grub2/grubenv.new
+#   - 50-depmod.install     -> depmod resolves its kernel version via
+#     `uname -r`, which in a container returns the HOST runner's
+#     kernel, and then fails because /lib/modules/<host-kernel> is
+#     absent
+#
+# None of those need to run at image-build time. bootc/ostree
+# regenerates the initramfs and updates the boot config at first
+# boot on the running system.
+#
+# Cannot use KERNEL_INSTALL_BYPASS — kernel-install does not honour
+# it (verified via `strings` on the binary). Can't use
+# KERNEL_INSTALL_LAYOUT=none either — kernel-install still runs the
+# plugins for "other" layouts. The only reliable bypass is to move
+# the plugin files out of the plugin directory entirely and restore
+# them afterwards. Bazzite does a narrower version of the same thing
+# in their install-kernel (PR history).
+INSTALL_D=/usr/lib/kernel/install.d
+INSTALL_D_STASH=/tmp/kernel-install.d.stash
+mkdir -p "${INSTALL_D_STASH}"
+# Sweep every *.install into the stash. The [[ -e ]] guard handles
+# the "no matches" case without needing shopt nullglob.
+STASHED_PLUGINS=()
+for plugin in "${INSTALL_D}"/*.install; do
+    [[ -e "${plugin}" ]] || continue
+    mv "${plugin}" "${INSTALL_D_STASH}/$(basename "${plugin}")"
+    STASHED_PLUGINS+=("$(basename "${plugin}")")
+done
+echo "Stashed ${#STASHED_PLUGINS[@]} kernel-install.d plugins"
 
 # Install the pinned kernel RPMs from the akmods bind mount.
 # Globs match the bluefin pattern (kernel-[0-9]*.rpm catches kernel-<version>
@@ -137,15 +160,16 @@ if [[ "${BASE_IMAGE}" == *nvidia* ]]; then
         "${AKMODS_NVIDIA_SRC}"/rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 fi
 
-# Restore the real kernel-install.d plugins. Must happen BEFORE
-# versionlock (which is not strictly kernel-install related) and
-# BEFORE the script returns — the actual initramfs regeneration
-# will fire at first boot via bootc/ostree, which needs these
-# plugins in place.
-pushd /usr/lib/kernel/install.d >/dev/null
-mv -f 05-rpmostree.install.bak 05-rpmostree.install
-mv -f 50-dracut.install.bak 50-dracut.install
-popd >/dev/null
+# Restore every stashed plugin. Subsequent build scripts
+# (10-build.sh → 20-1password.sh → ...) and more importantly the
+# running system at first boot all need these present so that
+# kernel-install works normally. Missing this restore would make the
+# installed image unusable.
+for plugin in "${STASHED_PLUGINS[@]}"; do
+    mv "${INSTALL_D_STASH}/${plugin}" "${INSTALL_D}/${plugin}"
+done
+rmdir "${INSTALL_D_STASH}"
+echo "Restored ${#STASHED_PLUGINS[@]} kernel-install.d plugins"
 
 # Prevent any subsequent dnf5 operation in this or future builds from
 # bumping the kernel. The versionlock plugin is present in bluefin:stable

--- a/build/05-kernel-pin.sh
+++ b/build/05-kernel-pin.sh
@@ -81,6 +81,24 @@ fi
 # Clear stale module trees left behind by the erased packages.
 rm -rf /usr/lib/modules/*
 
+# Shim out the kernel-install.d plugins that fire from kernel-core's
+# %posttrans scriptlet. Inside a buildah container environment,
+# `05-rpmostree.install` calls `rpm-ostree kernel-install` which tries
+# to regenerate the initramfs via dracut and fails with "Invalid cross-
+# device link". The shim replaces both plugins with /bin/sh true stubs
+# for the duration of the dnf5 install, then restores them. initramfs
+# gets regenerated on the running system at first boot anyway, so
+# skipping it during the image build is safe.
+#
+# Pattern cribbed verbatim from bazzite's build_files/install-kernel.
+pushd /usr/lib/kernel/install.d >/dev/null
+mv 05-rpmostree.install 05-rpmostree.install.bak
+mv 50-dracut.install 50-dracut.install.bak
+printf '%s\n' '#!/bin/sh' 'exit 0' > 05-rpmostree.install
+printf '%s\n' '#!/bin/sh' 'exit 0' > 50-dracut.install
+chmod +x 05-rpmostree.install 50-dracut.install
+popd >/dev/null
+
 # Install the pinned kernel RPMs from the akmods bind mount.
 # Globs match the bluefin pattern (kernel-[0-9]*.rpm catches kernel-<version>
 # only, not kernel-core-* or kernel-modules-*).
@@ -118,6 +136,16 @@ if [[ "${BASE_IMAGE}" == *nvidia* ]]; then
         "${AKMODS_NVIDIA_SRC}"/rpms/kmods/kmod-nvidia-"${KERNEL_PIN}"-*.rpm \
         "${AKMODS_NVIDIA_SRC}"/rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 fi
+
+# Restore the real kernel-install.d plugins. Must happen BEFORE
+# versionlock (which is not strictly kernel-install related) and
+# BEFORE the script returns — the actual initramfs regeneration
+# will fire at first boot via bootc/ostree, which needs these
+# plugins in place.
+pushd /usr/lib/kernel/install.d >/dev/null
+mv -f 05-rpmostree.install.bak 05-rpmostree.install
+mv -f 50-dracut.install.bak 50-dracut.install
+popd >/dev/null
 
 # Prevent any subsequent dnf5 operation in this or future builds from
 # bumping the kernel. The versionlock plugin is present in bluefin:stable

--- a/build/05-kernel-pin.sh
+++ b/build/05-kernel-pin.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/bash
+set -eoux pipefail
+
+# Pin the kernel to a known-good version to avoid the amdgpu MES scheduler
+# hang on Strix Point (Framework 13 AMD). See docs/amdgpu-strix-point-gpu-hang.md.
+#
+# Mechanism is a close port of bluefin's build_files/base/03-install-kernel-akmods.sh
+# from PR ublue-os/bluefin#4187 (Feb 2026). Differences:
+#   - Rocinante is downstream of bluefin:stable, so the swap happens in our
+#     own build rather than in bluefin's.
+#   - Kernel + kmod RPMs arrive via --mount=type=bind,from=<akmods-stage>
+#     (configured in the Containerfile), which is cheaper than the skopeo-copy-
+#     then-tar-extract dance bluefin uses inside their script.
+#   - Nvidia-open and ZFS kmods come from their own akmods-<variant> images
+#     (plain akmods only has common kmods).
+#
+# Exit criterion: remove this script and revert the Containerfile when
+# kernel 7.0+ lands in Fedora stable (expected MES scheduler improvements
+# for gfx1150) OR when upstream bluefin re-pins via PR #4187's mechanism.
+# See docs/amdgpu-strix-point-gpu-hang.md for current status.
+
+KERNEL_PIN="${KERNEL_PIN:?KERNEL_PIN must be set by the Containerfile}"
+BASE_IMAGE="${BASE_IMAGE:-}"
+
+# Bind-mounted by the Containerfile RUN step
+AKMODS_SRC=/akmods-src
+AKMODS_ZFS_SRC=/akmods-zfs-src
+AKMODS_NVIDIA_SRC=/akmods-nvidia-open-src
+
+echo "::group:: Pin kernel to ${KERNEL_PIN}"
+
+# Sanity check: the akmods bind mount must contain the kernel RPMs we need.
+# If this fires, the Containerfile's multi-stage tag probably doesn't match
+# KERNEL_PIN, or the upstream akmods image layout has changed.
+if [[ ! -f "${AKMODS_SRC}/kernel-rpms/kernel-core-${KERNEL_PIN}.rpm" ]]; then
+    echo "ERROR: ${AKMODS_SRC}/kernel-rpms/kernel-core-${KERNEL_PIN}.rpm not found"
+    echo "Contents of ${AKMODS_SRC}:"
+    ls -la "${AKMODS_SRC}" || true
+    ls -la "${AKMODS_SRC}/kernel-rpms" || true
+    exit 1
+fi
+
+# Discover currently installed kernel-version-tied packages.
+# kernel-headers, kernel-tools, kernel-tools-libs are userspace and may
+# lag the running kernel on upstream — don't touch them.
+mapfile -t OLD_KERNEL_PKGS < <(
+    rpm -qa --qf '%{NAME}\n' \
+        kernel \
+        kernel-core \
+        kernel-modules \
+        kernel-modules-core \
+        kernel-modules-extra \
+        kernel-devel \
+        kernel-devel-matched 2>/dev/null | sort -u
+)
+echo "Installed kernel packages to erase:"
+printf '  %s\n' "${OLD_KERNEL_PKGS[@]}"
+
+# Discover currently installed kmod-* packages that are kernel-version-tied.
+# Exclude the plain 'kmod' and 'kmod-libs' userspace tools.
+mapfile -t OLD_KMODS < <(
+    rpm -qa --qf '%{NAME}\n' 'kmod-*' 2>/dev/null \
+        | grep -vE '^(kmod|kmod-libs)$' \
+        | sort -u
+)
+echo "Installed kmods to erase:"
+printf '  %s\n' "${OLD_KMODS[@]}"
+
+# Erase the old kernel (--nodeps because kmods still depend on it; we'll
+# reinstall matching versions in a moment).
+if [[ ${#OLD_KERNEL_PKGS[@]} -gt 0 ]]; then
+    rpm --erase --nodeps "${OLD_KERNEL_PKGS[@]}"
+fi
+
+# Erase the old kmods (--nodeps in case anything in the base image Requires
+# them; versions are about to be replaced).
+if [[ ${#OLD_KMODS[@]} -gt 0 ]]; then
+    rpm --erase --nodeps "${OLD_KMODS[@]}" || true
+fi
+
+# Clear stale module trees left behind by the erased packages.
+rm -rf /usr/lib/modules/*
+
+# Install the pinned kernel RPMs from the akmods bind mount.
+# Globs match the bluefin pattern (kernel-[0-9]*.rpm catches kernel-<version>
+# only, not kernel-core-* or kernel-modules-*).
+dnf5 -y install \
+    "${AKMODS_SRC}"/kernel-rpms/kernel-[0-9]*.rpm \
+    "${AKMODS_SRC}"/kernel-rpms/kernel-core-*.rpm \
+    "${AKMODS_SRC}"/kernel-rpms/kernel-modules-*.rpm \
+    "${AKMODS_SRC}"/kernel-rpms/kernel-devel*.rpm
+
+# Install matching common kmods. We only restore what rocinante actually
+# uses: framework-laptop (FW13 hardware support) and v4l2loopback (OBS
+# virtual cameras). Skip wl, xone, xpadneo, openrazer — not needed here.
+dnf5 -y install \
+    "${AKMODS_SRC}"/rpms/kmods/kmod-framework-laptop-*.rpm \
+    "${AKMODS_SRC}"/rpms/kmods/kmod-v4l2loopback-*.rpm \
+    "${AKMODS_SRC}"/rpms/ublue-os/ublue-os-akmods-addons-*.rpm
+
+# Install matching ZFS kmod + userspace libs built against the pinned kernel.
+# Bluefin's ZFS_RPMS glob pattern (PR #4187) — match version-number suffixes
+# to avoid pulling in debug/devel subpackages from /rpms/kmods/zfs/{debug,devel}/.
+dnf5 -y install \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/kmod-zfs-"${KERNEL_PIN}"-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libnvpair[0-9]-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libuutil[0-9]-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libzfs[0-9]-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/libzpool[0-9]-*.rpm \
+    "${AKMODS_ZFS_SRC}"/rpms/kmods/zfs/python3-pyzfs-*.rpm
+
+# Nvidia-open variant: restore kmod-nvidia built against the pinned kernel.
+# Userspace nvidia libs come from the bluefin-nvidia-open base image and
+# are not kernel-version-tied, so they survive the erase unchanged.
+if [[ "${BASE_IMAGE}" == *nvidia* ]]; then
+    echo "NVIDIA variant detected, installing matching kmod-nvidia"
+    dnf5 -y install \
+        "${AKMODS_NVIDIA_SRC}"/rpms/kmods/kmod-nvidia-"${KERNEL_PIN}"-*.rpm \
+        "${AKMODS_NVIDIA_SRC}"/rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
+fi
+
+# Prevent any subsequent dnf5 operation in this or future builds from
+# bumping the kernel. The versionlock plugin is present in bluefin:stable
+# (used by the same mechanism in PR #4187).
+dnf5 versionlock add \
+    kernel \
+    kernel-core \
+    kernel-modules \
+    kernel-modules-core \
+    kernel-modules-extra \
+    kernel-devel \
+    kernel-devel-matched
+
+# Verify the installed kernel matches the pin. Fail loud if not.
+INSTALLED_EVR=$(rpm -q kernel-core --qf '%{EVR}.%{ARCH}\n')
+if [[ "${INSTALLED_EVR}" != "${KERNEL_PIN}" ]]; then
+    echo "ERROR: kernel-core is ${INSTALLED_EVR}, expected ${KERNEL_PIN}"
+    exit 1
+fi
+echo "Kernel pinned: ${INSTALLED_EVR}"
+
+echo "::endgroup::"

--- a/build/10-build.sh
+++ b/build/10-build.sh
@@ -4,6 +4,10 @@ set -eoux pipefail
 source /ctx/build/copr-helpers.sh
 shopt -s nullglob
 
+# Pin the kernel FIRST, before any other dnf operations that could pull
+# in kernel-version-coupled packages. See build/05-kernel-pin.sh.
+/ctx/build/05-kernel-pin.sh
+
 echo "::group:: Install Brew"
 rsync -rvK /ctx/oci/brew/ /
 systemctl preset brew-setup.service

--- a/docs/amdgpu-strix-point-gpu-hang.md
+++ b/docs/amdgpu-strix-point-gpu-hang.md
@@ -40,9 +40,63 @@ This is a known upstream bug in the `amdgpu` driver affecting Strix Point GPUs. 
 - **Kernel**: 6.17.x (known good range; 6.18.x and 6.19.x are **worse**)
 - **Firmware**: linux-firmware-20260110
 
+## Build-time kernel pin (rocinante)
+
+Since PR #77, the rocinante image pins the kernel to **6.17.12-300.fc43.x86_64**
+at build time via `build/05-kernel-pin.sh`. This prevents the image from
+inheriting whichever kernel `ghcr.io/ublue-os/bluefin:stable` happens to
+ship — upstream bluefin crossed into the bad 6.18.x range on 2026-03-03
+and then into 6.19.7 on 2026-04-07, at which point the MES hang became
+reproducible on Framework 13 AMD during normal use.
+
+The pin is a close port of the mechanism from [bluefin PR #4187]
+(https://github.com/ublue-os/bluefin/pull/4187). Kernel and matching
+akmod RPMs are sourced from pre-built upstream images:
+
+- `ghcr.io/ublue-os/akmods:coreos-stable-43-6.17.12-300.fc43.x86_64`
+  (kernel-core, kernel-modules, framework-laptop + v4l2loopback kmods)
+- `ghcr.io/ublue-os/akmods-zfs:coreos-stable-43-6.17.12-300.fc43.x86_64`
+  (zfs kmod and userspace libs built against the pinned kernel)
+- `ghcr.io/ublue-os/akmods-nvidia-open:coreos-stable-43-6.17.12-300.fc43.x86_64`
+  (kmod-nvidia for the rocinante-nvidia variant)
+
+`dnf5 versionlock` prevents subsequent build steps from bumping the
+kernel. Verify on a running system:
+
+```bash
+rpm-ostree status          # Version line includes the image tag
+uname -r                   # Should report 6.17.12-300.fc43.x86_64
+rpm -q kernel-core         # Same
+```
+
+### Exit criterion
+
+Remove `build/05-kernel-pin.sh`, the multi-stage `FROM`s in
+`Containerfile`, and the `KERNEL_PIN` build-arg in
+`.github/workflows/build.yml` when **any** of the following becomes true:
+
+1. **Kernel 7.0+** lands in Fedora 43 stable. Per the kernel version notes
+   in the "Sleep/Suspend Fixes" section below, 7.0 is expected to include
+   MES scheduler improvements for gfx1150.
+2. **Upstream bluefin re-pins** via PR #4187's mechanism (uncomment the
+   `kernel_pin:` line in their build workflow). Rocinante inherits the
+   pinned kernel automatically in that case and our downstream pin becomes
+   redundant.
+3. **Fedora backports the MES fix** to 6.19.x or later such that
+   `journalctl -k | grep -i 'MES failed to respond'` stays clean for at
+   least a week of normal use on Framework 13 AMD.
+
+### Runtime fallback
+
+If you're somehow on a non-pinned kernel (e.g. a hand-built image, or a
+variant that was rebuilt without the build-arg), the runtime kernel
+parameter workarounds below remain effective as defense in depth.
+
 ## Workarounds
 
-These are machine-specific kernel parameters, not baked into the rocinante image. The recommended way to apply them is:
+These are machine-specific kernel parameters, used either as runtime
+defense in depth on top of the pinned kernel, or as a fallback when
+running on a non-pinned kernel. The recommended way to apply them is:
 
 ```bash
 ujust fix-amdgpu


### PR DESCRIPTION
## Summary

- Pin the build to kernel **6.17.12-300.fc43.x86_64** via a new `build/05-kernel-pin.sh` that runs first in the build chain. The build has never pinned the kernel; it has been inheriting whatever `ghcr.io/ublue-os/bluefin:stable` ships on every nightly rebuild, and upstream has been inside the "avoid" range (6.18.x / 6.19.x per `docs/amdgpu-strix-point-gpu-hang.md`) for **37 consecutive days**.
- The pin is a close port of the mechanism from [ublue-os/bluefin#4187](https://github.com/ublue-os/bluefin/pull/4187), adapted for rocinante's downstream position: three new multi-stage `FROM`s in the `Containerfile` pull pre-built kernel + matching akmod RPMs from `ghcr.io/ublue-os/akmods`, `akmods-zfs`, and `akmods-nvidia-open`; they're bind-mounted into the main build via `--mount=type=bind,from=<stage>,source=/,target=/akmods-src` so nothing is baked into intermediate image layers.
- `dnf5 versionlock` prevents any later build step from accidentally bumping the kernel.

## Evidence that the build has shipped a "bad" kernel since 2026-03-03

Audited every daily `latest.YYYYMMDD` tag via `skopeo inspect | jq '.Labels."ostree.linux"'`:

| Tag | Kernel | Status |
|---|---|---|
| `latest.20260302` | `6.17.12-300.fc43.x86_64` | Last doc-compliant build |
| `latest.20260303` | `6.18.7-200.fc43.x86_64` | First "avoid" build |
| `latest.20260406` | `6.18.13-200.fc43.x86_64` | Pre-VPE-fix; still unstable |
| `latest.20260407` | `6.19.7-200.fc43.x86_64` | Broken CWSR per doc; worst |
| `latest.20260408` | `6.19.7-200.fc43.x86_64` | Reproduced MES hang on Framework 13 AMD |

On 2026-04-08T17:39:19Z the running laptop (Framework 13 AMD, Ryzen AI 9 HX 370) hit exactly the hang the doc has been warning about: `amdgpu: MES failed to respond to msg=MISC (WAIT_REG_MEM)` → `amdgpu: MES ring buffer is full` → hard hang requiring power-button reset.

## Mechanism

**`Containerfile`** — three new multi-stage `FROM`s (plain akmods, akmods-zfs, akmods-nvidia-open), gated by new `ARG KERNEL_PIN=6.17.12-300.fc43.x86_64` and `ARG AKMODS_FLAVOR=coreos-stable-43`. The main build stage bind-mounts all three via `--mount=type=bind,from=<stage>,source=/,target=/akmods-*-src`.

**`build/05-kernel-pin.sh`** (new) — does the kernel swap:

1. Verify the bind mount has `kernel-core-${KERNEL_PIN}.rpm` (fail fast if the tag is wrong).
2. Discover currently installed kernel + kmod packages via `rpm -qa`.
3. `rpm --erase --nodeps` the old kernel + old kmods.
4. `rm -rf /usr/lib/modules/*` to clear stale module trees.
5. `dnf5 -y install` from the bind-mounted akmods sources (plain kernel RPMs from `/akmods-src/kernel-rpms/`, common kmods from `/akmods-src/rpms/kmods/`, ZFS from `/akmods-zfs-src/rpms/kmods/zfs/`, and nvidia-open kmods from `/akmods-nvidia-open-src/rpms/kmods/` only on the nvidia variant).
6. `dnf5 versionlock add` on the kernel package set.
7. Final verification that `kernel-core` reports `${KERNEL_PIN}` or `exit 1`.

Header comments point at both upstream bluefin PR #4187 and the exit criterion in `docs/amdgpu-strix-point-gpu-hang.md`.

**`build/10-build.sh`** — two-line change: calls `05-kernel-pin.sh` first, before any other dnf5 operation.

**`.github/workflows/build.yml`** — one-line addition: `KERNEL_PIN=6.17.12-300.fc43.x86_64` in the `build-args:` block. Shared across all three matrix entries; the variant detection (nvidia vs. plain) happens inside the build script based on `$BASE_IMAGE`.

**Documentation**:
- `docs/amdgpu-strix-point-gpu-hang.md` grows a new **Build-time kernel pin (rocinante)** section near the top with the exit criterion (remove when 7.0+ lands or upstream re-pins).
- `AGENTS.md` documents the kernel pin alongside the existing firmware pin.

## Alternatives considered

- **Bazzite kernel** — ships 6.17.5 (older than our target), handheld/gaming patches have no amdgpu/MES fixes relevant to Strix Point, introduces kmod ABI skew. Rejected.
- **Koji fetch for kernel RPMs** (like `build/50-firmware.sh` does for linux-firmware) — works but duplicates what `ghcr.io/ublue-os/akmods` already publishes. Using the akmods image is cheaper and matches the mechanism upstream uses.
- **Workflow-level `kernel_pin:` à la bluefin #4187** — doesn't work here because rocinante is `FROM bluefin:stable`, so the kernel is already baked into the base by the time rocinante builds.

## Verification

- [x] Shellcheck clean on `build/05-kernel-pin.sh` and all other `build/*.sh`.
- [x] `skopeo inspect` confirms all three akmods source tags exist and carry `ostree.linux = 6.17.12-300.fc43.x86_64`.
- [x] Manual extraction of the akmods layer tarball confirms `/kernel-rpms/` and `/rpms/kmods/` contain the expected RPMs for all three images (plain, zfs, nvidia-open).
- [ ] CI matrix build on this PR — three variants succeed.
- [ ] `skopeo inspect ghcr.io/allardvdb/rocinante:sha-<abbrev>` reports `ostree.linux = 6.17.12-300.fc43.x86_64` for all three variants.
- [ ] Post-merge soak on Framework 13 AMD: `sudo bootc switch ghcr.io/allardvdb/rocinante:latest && reboot`, then ≥24 h of normal use with `journalctl -k | grep -i 'MES failed to respond'` staying empty.

## Test plan

- [ ] Triggered PR build (this PR) succeeds for all three matrix variants
- [ ] `skopeo inspect` confirms `ostree.linux = 6.17.12-300.fc43.x86_64` on the PR images
- [ ] After merge, rebase Framework 13 AMD laptop to the new `latest` and reboot
- [ ] Verify `uname -r` reports `6.17.12-300.fc43.x86_64`
- [ ] Verify hibernate round-trip still works (PR #76 machinery)
- [ ] Soak for 24 h without MES hang — `journalctl -k | grep -i 'MES failed to respond'` stays empty

## Exit criterion

Documented in `docs/amdgpu-strix-point-gpu-hang.md` — remove this pin when any of:
1. Kernel 7.0+ lands in Fedora 43 stable (expected to include MES scheduler improvements for gfx1150).
2. Upstream bluefin re-pins via PR #4187's mechanism (reverts their own `# kernel_pin:` comment).
3. Fedora backports the MES fix to 6.19.x or later such that the hang stops reproducing on Framework 13 AMD for a week of normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)