### PR TITLE
fix(incus): replace broken Fedora incus-agent with upstream binary

### DIFF
--- a/build/30-incus.sh
+++ b/build/30-incus.sh
@@ -16,6 +16,26 @@ dnf5 install -y \
     swtpm
 echo "::endgroup::"
 
+echo "::group:: Override broken Fedora incus-agent with upstream binary"
+# Workaround for Fedora bug #2419661 — the Fedora incus-agent binary is built
+# with GO111MODULE=off and fails "websocket: bad handshake" inside VMs, which
+# breaks `incus exec`, `incus file push/pull`, and VM IP discovery via
+# `incus list`. Replace with the upstream prebuilt static binary, version-
+# matched to the installed `incus` package so host + agent stay in sync.
+INCUS_VERSION="$(rpm -q --queryformat '%{VERSION}' incus)"
+INCUS_AGENT_URL="https://github.com/lxc/incus/releases/download/v${INCUS_VERSION}/bin.linux.incus-agent.x86_64"
+echo "Validating upstream agent URL: ${INCUS_AGENT_URL}"
+if ! curl -sf -I --max-time 10 --retry 2 "${INCUS_AGENT_URL}" > /dev/null; then
+    echo "ERROR: upstream incus-agent not found at ${INCUS_AGENT_URL}"
+    echo "The Fedora incus version (${INCUS_VERSION}) may not have a matching upstream tag."
+    exit 1
+fi
+curl -fL --retry 3 --max-time 60 -o /usr/bin/incus-agent "${INCUS_AGENT_URL}"
+chmod 0755 /usr/bin/incus-agent
+file /usr/bin/incus-agent
+sha256sum /usr/bin/incus-agent
+echo "::endgroup::"
+
 echo "::group:: Configure Incus Services"
 systemctl preset incus.socket
 systemctl preset incus-user.socket


### PR DESCRIPTION
## Summary
- Override `/usr/bin/incus-agent` at image build time with the upstream prebuilt static binary from `lxc/incus` GitHub releases, version-matched to the installed Fedora `incus` package.
- Workaround for Fedora bug [#2419661](https://bugzilla.redhat.com/show_bug.cgi?id=2419661): the Fedora `incus-agent` is built with `GO111MODULE=off` and fails `websocket: bad handshake` inside VMs, breaking `incus exec`, `incus file push/pull`, and `incus list` IP discovery. The "fix" in `incus-6.19.1-1.fc43` does not resolve it.
- URL is validated with `curl -sf -I` before overwriting (mirroring `build/50-firmware.sh`), so a missing upstream tag fails the build loudly instead of silently leaving the broken binary in place.

Fixes #80

## Test plan
- [ ] CI build of the image succeeds and the new `Override broken Fedora incus-agent` group logs `file` + `sha256sum` of a freshly downloaded binary
- [ ] After rebasing `ri` onto the new image, `file /usr/bin/incus-agent` and `sha256sum` differ from the Fedora-shipped binary
- [ ] `incus launch images:ubuntu/24.04 test-vm-80 --vm` then `incus exec test-vm-80 -- uname -a` succeeds (no `websocket: bad handshake`)
- [ ] `incus list test-vm-80` shows a populated `IPV4` column
- [ ] Regression check: `incus exec iqprod2 -- hostname` succeeds against the pre-existing VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)